### PR TITLE
Spelling fixes for Planetfall

### DIFF
--- a/compone.zil
+++ b/compone.zil
@@ -366,7 +366,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 north.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -400,7 +400,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 south.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -434,7 +434,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 north.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0
@@ -468,7 +468,7 @@ deserted now. There are openings at the north and south ends of the room.")
       (LDESC
 "This must be the sanitary facility for the adjacent dormitory. The fixtures
 are dry and dusty, the room dead and deserted. You marvel at how little the
-millenia and cultural gulfs have changed toilet bowl design. The only exit is
+millennia and cultural gulfs have changed toilet bowl design. The only exit is
 south.")
       (C-MOVE  <TABLE
          ;"OUT" 0 ;"IN"   0 ;"DOWN" 0  ;"UP"     0

--- a/globals.zil
+++ b/globals.zil
@@ -2671,7 +2671,7 @@ Planetfall, you blow it all in one amazingly dumb input.|
 |
 The doors close and the elevator rises quickly to the top of the shaft. The
 doors open, and the mutants, which were waiting impatiently in the ProjCon
-Office for just such an occurence, happily saunter in and begin munching.">)>>
+Office for just such an occurrence, happily saunter in and begin munching.">)>>
 
 <ROUTINE CASTLE-PSEUDO ()
 	 <COND (<VERB? EXAMINE>

--- a/globals.zil
+++ b/globals.zil
@@ -959,7 +959,7 @@ translator slung around his neck." CR>)
 	 <COND (<AND <VERB? EXAMINE>
 		     <EQUAL? .RARG ,M-OBJECT>>
 		<TELL
-"The safety webbing fills most of the pod. It could accomodate
+"The safety webbing fills most of the pod. It could accommodate
 from one to, perhaps, twenty people." CR>)
 	       (<AND <VERB? TAKE>
 		     <EQUAL? .RARG ,M-OBJECT>>


### PR DESCRIPTION
These are the spelling fixes for Planetfall from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.